### PR TITLE
change CIDR notation on the 172.16 network to give it the true full r…

### DIFF
--- a/waf-owasp-top-10/owasp_10_base.yml
+++ b/waf-owasp-top-10/owasp_10_base.yml
@@ -1026,7 +1026,7 @@ Resources:
         - Type: IPV4
           Value: 169.254.0.0/16
         - Type: IPV4
-          Value: 172.16.0.0/16
+          Value: 172.16.0.0/12
         - Type: IPV4
           Value: 127.0.0.1/32
   wafgBlacklistIpSet:


### PR DESCRIPTION


change the ip black list cidr notation to reflect the true size/range of IPs in the 172.16.0.0 network (from /16 to /12).